### PR TITLE
Tag tests covered by cypress in influxdb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: docker-build docker-prep docker-test docker-test-kill docker-report test clean
+
+RUNCMD ?= cucumber-js --tags 'not @tested and not @error-collateral'
+
+docker-build:
+	docker build -t bonitoo-tests -f scripts/Dockerfile.bonitoo .
+
+docker-prep:
+	mkdir -p /tmp/report \
+  && docker pull quay.io/influxdb/influx:nightly
+	docker run -d --rm --name=test-influxdb quay.io/influxdb/influx:nightly influxd --e2e-testing=true \
+	&& sleep 30s
+
+docker-test: docker-build
+	docker run --rm --name=test-bonitoo -v /tmp/report:/selenium-accept-infl2/report --network=container:test-influxdb bonitoo-tests ${RUNCMD}
+
+docker-report:
+	docker run --rm -t --name=test-bonitoo -v /tmp/report:/selenium-accept-infl2/report bonitoo-tests npm run report:html
+
+docker-test-kill:
+	docker rm -f test-bonitoo
+
+test: docker-test docker-report
+
+clean:
+	docker rm -f test-influxdb
+	rm -rf /tmp/report

--- a/features/dashboards/cellEdit.feature
+++ b/features/dashboards/cellEdit.feature
@@ -4,6 +4,7 @@ Feature: Dashboards - Dashboard - Cell Edit
   As a user I want to Create and Update Cells
   So that I can view specific Influxdbv2 data
 
+@tested
   Scenario: Load Cell Edit View
     Given I reset the environment
     Given run setup over REST "DEFAULT"
@@ -55,6 +56,7 @@ Feature: Dashboards - Dashboard - Cell Edit
              # +Aggregate functions
              # +Variables
 
+@tested
   Scenario: Exercise Basic Cell Edit Controls
     When click the empty create cell button
     Then the cell edit overlay is loaded as "Name this Cell"
@@ -123,6 +125,7 @@ Feature: Dashboards - Dashboard - Cell Edit
        # ~~switch-to-script-editor
        # ~~switch-to-query-builder
 
+@tested
   Scenario: Exercise Query Builder
     When toggle context menu of dashboard cell named "Kliky"
     When click cell content popover configure
@@ -210,6 +213,7 @@ Feature: Dashboards - Dashboard - Cell Edit
     Then there are "1" time machine builder cards
   # Check coverage of issue 16682 once fixed
 
+@tested
   Scenario: Exercise Query Builder Functions
     # TODO 16682 - following will not have been reset
     # Then the time machine query builder function duration period is "auto"
@@ -247,6 +251,7 @@ Feature: Dashboards - Dashboard - Cell Edit
     Then the time machine query builder function duration period is "auto (10s)"
     When click dashboard cell edit cancel button
 
+@tested
   Scenario: Create basic query
     Then the cell named "Kliky" contains the empty graph message
     When toggle context menu of dashboard cell named "Kliky"
@@ -292,12 +297,6 @@ Feature: Dashboards - Dashboard - Cell Edit
     Then the time machine preview axes have changed
     When click dashboard cell save button
     Then the cell named "Kliky" contains a graph
-
-  #Scenario: Create Second Query
-    # Add Query
-    # Queries
-       # Schema navigator
-       # Aggregate functions
 
   Scenario: Create Second Query
     When get the current graph of the cell "Kliky"
@@ -358,6 +357,7 @@ Feature: Dashboards - Dashboard - Cell Edit
     Then the time machine preview axes have changed
     When click dashboard cell save button
 
+@tested
   Scenario: Delete Second Query
     When toggle context menu of dashboard cell named "Kliky"
     When click cell content popover configure
@@ -374,12 +374,7 @@ Feature: Dashboards - Dashboard - Cell Edit
     When click dashboard cell save button
     Then the graph of the cell "Kliky" has changed
 
-  #Scenario: Edit Query
-    # time-machine--bottom
-       # switch-to-script-editor
-       # Queries
-          # Script Editor
-
+@tested
   Scenario: Edit Query
     When get the current graph of the cell "Kliky"
     When toggle context menu of dashboard cell named "Kliky"
@@ -407,6 +402,7 @@ Feature: Dashboards - Dashboard - Cell Edit
     When click the cell edit save button
     Then the graph of the cell "Kliky" has changed
 
+@tested
   Scenario: Switch to Query Builder
     When get the current graph of the cell "Kliky"
     When toggle context menu of dashboard cell named "Kliky"
@@ -433,6 +429,7 @@ Feature: Dashboards - Dashboard - Cell Edit
     When click dashboard cell edit cancel button
     Then the graph of the cell "Kliky" has not changed
 
+@tested
   Scenario:  Edit invalid query
     When get the current graph of the cell "Kliky"
     When toggle context menu of dashboard cell named "Kliky"
@@ -464,13 +461,7 @@ Feature: Dashboards - Dashboard - Cell Edit
   type error 1:1-1:7: undefined identifier "Muffin"
   """
 
-    #Scenario: Exercise Add functions - Query Builder
-    # time-machine--bottom
-        # Queries
-            # Builder
-              # +Aggregate functions
-
-
+@tested
   Scenario: Exercise Add functions - Query Builder
     When toggle context menu of dashboard cell named "Kliky"
     When click cell content popover configure
@@ -515,6 +506,7 @@ Feature: Dashboards - Dashboard - Cell Edit
     When click dashboard cell save button
     Then the cell named "Kliky" contains a graph
 
+@tested
   Scenario: Edit Query - Exercise functions
     When get the current graph of the cell "Kliky"
     When toggle context menu of dashboard cell named "Kliky"
@@ -558,6 +550,7 @@ Feature: Dashboards - Dashboard - Cell Edit
     Then the time machine query edit function popup is not visible
     When click dashboard cell edit cancel button
 
+@tested
   Scenario: Edit Query - Add a Function
     When get the current graph of the cell "Kliky"
     When toggle context menu of dashboard cell named "Kliky"
@@ -590,10 +583,6 @@ Feature: Dashboards - Dashboard - Cell Edit
     Then the time machine preview canvas has changed
     When click the cell edit save button
     Then the graph of the cell "Kliky" has changed
-
-  #Scenario: Change time range
-    # time-machine--bottom
-       # Time Range
 
   Scenario: Change time range
     When get the current graph of the cell "Kliky"

--- a/features/dashboards/cellEdit.feature
+++ b/features/dashboards/cellEdit.feature
@@ -266,10 +266,7 @@ Feature: Dashboards - Dashboard - Cell Edit
     Then the time machine cell edit preview graph is shown
     Then the time machine cell edit preview axes are shown
 
-    # +time-machine--bottom
-          # +Builder
-             # +Schema navigator
-         # +Submit#
+@error-collateral
   Scenario: Resize Preview
     When get metrics of time machine cell edit preview
     When get metrics of time machine query builder
@@ -298,6 +295,7 @@ Feature: Dashboards - Dashboard - Cell Edit
     When click dashboard cell save button
     Then the cell named "Kliky" contains a graph
 
+@error-collateral
   Scenario: Create Second Query
     When get the current graph of the cell "Kliky"
     When toggle context menu of dashboard cell named "Kliky"
@@ -328,6 +326,7 @@ Feature: Dashboards - Dashboard - Cell Edit
     When click dashboard cell save button
     Then the graph of the cell "Kliky" has changed
 
+@error-collateral
   Scenario: Change Query Name
     When get the current graph of the cell "Kliky"
     When toggle context menu of dashboard cell named "Kliky"
@@ -344,6 +343,7 @@ Feature: Dashboards - Dashboard - Cell Edit
     Then there is no time machine query tab named "Query 2"
     Then query "Dotaz B" is the active query in query builder
 
+@error-collateral
   Scenario: Hide Query
     When get time machine preview canvas
     When get time machine preview axes
@@ -584,6 +584,7 @@ Feature: Dashboards - Dashboard - Cell Edit
     When click the cell edit save button
     Then the graph of the cell "Kliky" has changed
 
+@error-collateral
   Scenario: Change time range
     When get the current graph of the cell "Kliky"
     When toggle context menu of dashboard cell named "Kliky"
@@ -603,6 +604,7 @@ Feature: Dashboards - Dashboard - Cell Edit
     #When select dashboard Time Range "24h"
     #Then the graph of the cell "Kliky" has changed
 
+@error-collateral
   Scenario: View raw data
     When toggle context menu of dashboard cell named "Kliky"
     When click cell content popover configure
@@ -619,14 +621,8 @@ Feature: Dashboards - Dashboard - Cell Edit
     Then the cell named "Kliky" contains a graph
 
 
-  #Scenario: View raw data
-
-    # time-machine--bottom
-         # raw-data--toggle
-    # time-machine--view
-        # raw-data-table
+@error-collateral
   Scenario: Download results as CSV
-     # clean any old CSVs
     When remove files ".*chronograf_data.csv" if exists
     When toggle context menu of dashboard cell named "Kliky"
     When click cell content popover configure
@@ -639,9 +635,7 @@ Feature: Dashboards - Dashboard - Cell Edit
     When click dashboard cell edit cancel button
     Then the cell named "Kliky" contains a graph
 
-  #Scenario: Download results as CSV
-       # CSV download
-
+@error-collateral
   Scenario: Refresh Rates
     #earlier signin may have timed out
     When API sign in user "DEFAULT"
@@ -681,19 +675,3 @@ Feature: Dashboards - Dashboard - Cell Edit
     """
     When wait "20" seconds
     Then the time machine preview canvas has not changed
-
-
-  #Scenario: Refresh Rates
-       # Refresh Rate
-       # Reload
-
-  #Scenario: Short Cut keys
-     # [CTRL + ENTER] -> Submit
-
-
-
-
-
-
-
-

--- a/features/dashboards/dashboard.feature
+++ b/features/dashboards/dashboard.feature
@@ -4,6 +4,7 @@ Feature: Dashboards - Dashboard - Base
   As a user I want to Read Create Update and Delete a Dashboard
   So that I can view specific Influxdbv2 data
 
+@tested
   Scenario: Load Initial Dashboard view
     Given I reset the environment
     Given run setup over REST "DEFAULT"
@@ -56,6 +57,7 @@ Feature: Dashboards - Dashboard - Base
     Custom Time Range,Past 5m,Past 15m,Past 1h,Past 6h,Past 12h,Past 24h,Past 2d,Past 7d,Past 30d
     """
 
+@tested
   Scenario: Create Cell
     When click the empty create cell button
     Then the cell edit overlay is loaded as "Name this Cell"
@@ -69,6 +71,7 @@ Feature: Dashboards - Dashboard - Base
     Then the dashboard contains a cell named "вре́менный"
 
     #Currently failing due to issue #16619
+@tested
   Scenario: Add Note to Cell
     When toggle context menu of dashboard cell named "вре́менный"
     When click cell content popover add note
@@ -106,6 +109,7 @@ Feature: Dashboards - Dashboard - Base
     When click the cell title "вре́менный"
     Then the cell content popover is not loaded
 
+@tested
   Scenario: Edit Cell Note
     When toggle context menu of dashboard cell named "вре́менный"
     When click cell content popover add note
@@ -172,6 +176,7 @@ Dans une administration russe... mieux vaut ne pas dire le nom de cette administ
     Then the location of the cell named "вре́менный" is unchanged
     When move the cell named "вре́менный" by "{ "dx": "-400", "dy": "0" }"
 
+@tested
   Scenario: Edit Cell - Simple
     Then the cell named "вре́менный" contains the empty graph message
     When toggle context menu of dashboard cell named "вре́менный"
@@ -239,6 +244,7 @@ Dans une administration russe... mieux vaut ne pas dire le nom de cette administ
     When Click at the point "{"x": "1/2", "y": "1/2"}" of graph cell named "вре́менный"
     Then the graph of the cell "вре́менный" has changed
 
+@tested
   Scenario: Rename Cell
     When toggle context menu of dashboard cell named "вре́менный"
     When click cell content popover configure
@@ -248,6 +254,7 @@ Dans une administration russe... mieux vaut ne pas dire le nom de cette administ
     When click the cell edit save button
     Then the cell named "dočasný" is visible in the dashboard
 
+@tested
   Scenario: Clone Cell
     When toggle context menu of dashboard cell named "dočasný"
     When click cell edit content popover clone
@@ -312,6 +319,7 @@ Dans une administration russe... mieux vaut ne pas dire le nom de cette administ
     When move the cell named "dočasný" by "{ "dx": "-150", "dy": "150" }"
     Then the location of the cell named "dočasný" is changed by "{ "dx": "-150", "dy": "+380" }"
 
+@tested
   Scenario Outline: Delete Cell
     When toggle context menu of dashboard cell named "<NAME>"
     When click cell content popover delete

--- a/features/dashboards/dashboard.feature
+++ b/features/dashboards/dashboard.feature
@@ -32,6 +32,7 @@ Feature: Dashboards - Dashboard - Base
     Then the empty dashboard contains Add a Cell button
     When name dashboard "про́бный прибо́ров"
 
+@error-collateral
   Scenario: Exercise Dashboard Dropdowns
     When click dashboard time locale dropdown
     Then the active dashboard dropdown contains items:
@@ -152,6 +153,7 @@ Dans une administration russe... mieux vaut ne pas dire le nom de cette administ
     When click the cell title "вре́менный"
     Then the cell content popover is not loaded
 
+@error-collateral
   Scenario: Move cell
     When get metrics of cell named "вре́менный"
     When move the cell named "вре́менный" by "{ "dx": "+400", "dy": "+200" }"
@@ -201,6 +203,7 @@ Dans une administration russe... mieux vaut ne pas dire le nom de cette administ
     When select dashboard Time Range "30d"
     Then the cell named "вре́менный" contains a graph
 
+@error-collateral
   Scenario: Resize Cell
     When get the current graph of the cell "вре́менный"
     When get metrics of cell named "вре́менный"
@@ -218,27 +221,32 @@ Dans une administration russe... mieux vaut ne pas dire le nom de cette administ
     #Then the dashboard named "про́бный прибо́ров" is loaded
     #Then the size of the of the cell named "вре́менный" is unchangd
 
+@error-collateral
   Scenario: Hover Cell Graph
     When hover over the graph of the cell named "вре́менный"
     Then the cell graph data point infobox is visible
 
+@error-collateral
   Scenario: Zoom Cell horizontal
     When get the current graph of the cell "вре́менный"
     When move horizontally to "2/5" of graph cell named "вре́менный"
     When drag horizontally to "3/5" of graph cell named "вре́менный"
     Then the graph of the cell "вре́менный" has changed
 
+@error-collateral
   Scenario: Unzoom Cell
     When get the current graph of the cell "вре́менный"
     When Click at the point "{"x": "1/2", "y": "1/2"}" of graph cell named "вре́менный"
     Then the graph of the cell "вре́менный" has changed
 
+@error-collateral
   Scenario: Zoom Cell vertical
     When get the current graph of the cell "вре́менный"
     When move vertically to "2/5" of graph cell named "вре́менный"
     When drag vertically to "3/5" of graph cell named "вре́менный"
     Then the graph of the cell "вре́менный" has changed
 
+@error-collateral
   Scenario: Unzoom Cell 2
     When get the current graph of the cell "вре́менный"
     When Click at the point "{"x": "1/2", "y": "1/2"}" of graph cell named "вре́менный"
@@ -284,18 +292,21 @@ Dans une administration russe... mieux vaut ne pas dire le nom de cette administ
     When click the cell title "klouzavý průměr"
     Then the cell content popover is not loaded
 
+@error-collateral
   Scenario: Two cells column to row
     When get metrics of cell named "dočasný"
     When get metrics of cell named "klouzavý průměr"
     When move the cell named "dočasný" by "{ "dx": "+300", "dy": "0" }"
     Then the location of the cell named "klouzavý průměr" is changed by "{ "dx": "0", "dy": "-380" }"
 
+@error-collateral
   Scenario: Two cells row to column
     When get metrics of cell named "dočasný"
     When get metrics of cell named "klouzavý průměr"
     When move the cell named "dočasný" by "{ "dx": "-300", "dy": "0" }"
     Then the location of the cell named "klouzavý průměr" is changed by "{ "dx": "0", "dy": "+380" }"
 
+@error-collateral
   Scenario: Two cells enlarge first into second
     When get metrics of cell named "klouzavý průměr"
     When move the cell named "dočasný" by "{ "dx": "+300", "dy": "0" }"
@@ -306,6 +317,7 @@ Dans une administration russe... mieux vaut ne pas dire le nom de cette administ
     Then the location of the cell named "dočasný" is changed by "{ "dx": "0", "dy": "+380" }"
     Then size of the cell named "klouzavý průměr" has changed by "{ "dw": "+300", "dh": "0" }"
 
+@error-collateral
   Scenario: Two cells reduce first when above second
     When get metrics of cell named "dočasný"
     When get metrics of cell named "klouzavý průměr"
@@ -313,6 +325,7 @@ Dans une administration russe... mieux vaut ne pas dire le nom de cette administ
     Then the location of the cell named "dočasný" is changed by "{ "dx": "0", "dy": "-380" }"
     Then size of the cell named "klouzavý průměr" has changed by "{ "dw": "-300", "dh": "0" }"
 
+@error-collateral
   Scenario: Two cells column to row - Moved cell drops down
     When get metrics of cell named "dočasný"
     When get metrics of cell named "klouzavý průměr"
@@ -334,7 +347,4 @@ Dans une administration russe... mieux vaut ne pas dire le nom de cette administ
     |klouzavý průměr|
     |dočasný        |
 
-
 # TODO - Dark Mode / Light Mode
-
-

--- a/features/dashboards/dashboard.feature
+++ b/features/dashboards/dashboard.feature
@@ -248,7 +248,6 @@ Dans une administration russe... mieux vaut ne pas dire le nom de cette administ
     When click the cell edit save button
     Then the cell named "dočasný" is visible in the dashboard
 
-@error-timeout
   Scenario: Clone Cell
     When toggle context menu of dashboard cell named "dočasný"
     When click cell edit content popover clone
@@ -278,21 +277,18 @@ Dans une administration russe... mieux vaut ne pas dire le nom de cette administ
     When click the cell title "klouzavý průměr"
     Then the cell content popover is not loaded
 
-@error-feature
   Scenario: Two cells column to row
     When get metrics of cell named "dočasný"
     When get metrics of cell named "klouzavý průměr"
     When move the cell named "dočasný" by "{ "dx": "+300", "dy": "0" }"
     Then the location of the cell named "klouzavý průměr" is changed by "{ "dx": "0", "dy": "-380" }"
 
-@error-feature
   Scenario: Two cells row to column
     When get metrics of cell named "dočasný"
     When get metrics of cell named "klouzavý průměr"
     When move the cell named "dočasný" by "{ "dx": "-300", "dy": "0" }"
     Then the location of the cell named "klouzavý průměr" is changed by "{ "dx": "0", "dy": "+380" }"
 
-@error-feature
   Scenario: Two cells enlarge first into second
     When get metrics of cell named "klouzavý průměr"
     When move the cell named "dočasný" by "{ "dx": "+300", "dy": "0" }"
@@ -303,7 +299,6 @@ Dans une administration russe... mieux vaut ne pas dire le nom de cette administ
     Then the location of the cell named "dočasný" is changed by "{ "dx": "0", "dy": "+380" }"
     Then size of the cell named "klouzavý průměr" has changed by "{ "dw": "+300", "dh": "0" }"
 
-@error-feature
   Scenario: Two cells reduce first when above second
     When get metrics of cell named "dočasný"
     When get metrics of cell named "klouzavý průměr"
@@ -311,14 +306,12 @@ Dans une administration russe... mieux vaut ne pas dire le nom de cette administ
     Then the location of the cell named "dočasný" is changed by "{ "dx": "0", "dy": "-380" }"
     Then size of the cell named "klouzavý průměr" has changed by "{ "dw": "-300", "dh": "0" }"
 
-@error-feature
   Scenario: Two cells column to row - Moved cell drops down
     When get metrics of cell named "dočasný"
     When get metrics of cell named "klouzavý průměr"
     When move the cell named "dočasný" by "{ "dx": "-150", "dy": "150" }"
     Then the location of the cell named "dočasný" is changed by "{ "dx": "-150", "dy": "+380" }"
 
-@error-feature
   Scenario Outline: Delete Cell
     When toggle context menu of dashboard cell named "<NAME>"
     When click cell content popover delete

--- a/features/dashboards/dashboards.feature
+++ b/features/dashboards/dashboards.feature
@@ -159,6 +159,7 @@ Feature: Dashboards - Base
     Mercure,Venus,Terre,Mars,Jupiter
     """
 
+@error-collateral
   Scenario: Import Dashboard from file
     When click create dashboard control
     When click the create dashboard item "Import Dashboard"
@@ -232,6 +233,7 @@ Feature: Dashboards - Base
   # Scenario: Sort Dashboards by Modified time
   # TODO - implement after issue #15610 is resolved
 
+@error-collateral
   Scenario: Export Dashboard as Template
     When hover over dashboard card named "Alpha Centauri"
     When click export of the dashboard card named "Alpha Centauri"
@@ -241,6 +243,7 @@ Feature: Dashboards - Base
     Then a REST template document for user "DEFAULT" titled "Alpha Centauri-Template" exists
     Then close all notifications
 
+@error-collateral
   Scenario: Export Dashboard copy to clipboard
     When hover over dashboard card named "Jupiter"
     When click export of the dashboard card named "Jupiter"
@@ -252,6 +255,7 @@ Feature: Dashboards - Base
     When click the Export Dashboard dismiss button
     Then popup is not loaded
 
+@error-collateral
   Scenario: Export Dashboard to file
     When remove file "tau_ceti.json" if exists
     When hover over dashboard card named "Tau Ceti"

--- a/features/dashboards/dashboards.feature
+++ b/features/dashboards/dashboards.feature
@@ -163,7 +163,6 @@ Feature: Dashboards - Base
     Then close all notifications
     Then there is a dashboard card named "Alpha Centauri"
 
-@error-timeout
   Scenario: Import Dashboard paste json
     When click create dashboard control
     When click the create dashboard item "Import Dashboard"
@@ -177,7 +176,6 @@ Feature: Dashboards - Base
     Then close all notifications
     Then there is a dashboard card named "Tau Ceti"
 
-@error-timeout
   Scenario: Create Dashboard from template
     When create a new template from the file "etc/test-data/sine-test-template.json" for user "DEFAULT"
     When click nav menu item "Dashboards"
@@ -201,7 +199,6 @@ Feature: Dashboards - Base
     When click Dashboard from Template create button
     Then there is a dashboard card named "Sinusoid test data"
 
-@error-collateral
   Scenario: Sort Dashboards by Name
     When close all notifications
     Then the dashboards are sorted as:
@@ -224,7 +221,6 @@ Feature: Dashboards - Base
   # Scenario: Sort Dashboards by Modified time
   # TODO - implement after issue #15610 is resolved
 
-@error-feature
   Scenario: Export Dashboard as Template
     When hover over dashboard card named "Alpha Centauri"
     When click export of the dashboard card named "Alpha Centauri"
@@ -234,7 +230,6 @@ Feature: Dashboards - Base
     Then a REST template document for user "DEFAULT" titled "Alpha Centauri-Template" exists
     Then close all notifications
 
-@error-feature
   Scenario: Export Dashboard copy to clipboard
     When hover over dashboard card named "Jupiter"
     When click export of the dashboard card named "Jupiter"
@@ -246,7 +241,6 @@ Feature: Dashboards - Base
     When click the Export Dashboard dismiss button
     Then popup is not loaded
 
-@error-feature
   Scenario: Export Dashboard to file
     When remove file "tau_ceti.json" if exists
     When hover over dashboard card named "Tau Ceti"
@@ -263,7 +257,6 @@ Feature: Dashboards - Base
     Then the file "tau_ceti.json" has been downloaded
     When remove file "tau_ceti.json" if exists
 
-@error-feature
   Scenario: Clone Dashboard
     When hover over dashboard card named "Tau Ceti"
     When click clone of the dashboard card named "Tau Ceti"
@@ -277,7 +270,6 @@ Feature: Dashboards - Base
     #When click nav sub menu "Dashboards"
     Then there is a dashboard card named "Tau Ceti (clone 1)"
 
-@error-feature
   Scenario Outline: Delete dashboards
     When hover over dashboard card named "<NAME>"
     When click delete of dashboard card "<NAME>"

--- a/features/dashboards/dashboards.feature
+++ b/features/dashboards/dashboards.feature
@@ -4,6 +4,7 @@ Feature: Dashboards - Base
   As a user I want to Read Create Update and Delete Dashboards
   So that I can organize my data in Influxdbv2
 
+@tested
   Scenario: Load dashboards page
     Given I reset the environment
     Given run setup over REST "DEFAULT"
@@ -26,6 +27,7 @@ Feature: Dashboards - Base
     """
 
 
+@tested
   Scenario: Create new dashboard
     When click the empty Create dashboard dropdown button
     Then the empty create dashboard dropdown list contains
@@ -40,6 +42,7 @@ Feature: Dashboards - Base
     Then the empty Create dashboard dropdown button is not present
     Then there is a dashboard card named "Name this Dashboard"
 
+@tested
   Scenario: Rename dashboard from card
     When hover over dashboard card named "Name this Dashboard"
     Then the export button for the dashboard card "Name this Dashboard" is visible
@@ -53,6 +56,7 @@ Feature: Dashboards - Base
     Then there is a dashboard card named "Mercure"
     Then there is no dashboard card named "Name this Dashboard"
 
+@tested
   Scenario: Add description to dashboard
     Then the description for card "Mercure" contains "No description"
     When hover over description of the dashboard card "Mercure"
@@ -64,6 +68,7 @@ Feature: Dashboards - Base
     When press the "ENTER" key
     Then the description for card "Mercure" contains "le dieu du commerce dans la mythologie romaine"
 
+@tested
   Scenario: Add Labels to dashboard
     # Issue 16529 - possible design change
     When click empty label for the dashboard card "Mercure"
@@ -102,6 +107,7 @@ Feature: Dashboards - Base
     When click the dashboards filter input
     Then the add label popover is not present
 
+@tested
   Scenario Outline: Create new Dashboard
     When click create dashboard control
     When click the create dashboard item "New Dashboard"
@@ -118,6 +124,7 @@ Feature: Dashboards - Base
     |Jupiter|
     |Mars |
 
+@tested
   Scenario: Access Dashboard from home page
     When hover over the "home" menu item
     When click nav menu item "home"
@@ -128,6 +135,7 @@ Feature: Dashboards - Base
     When click the dashboards panel link "Mercure"
     Then the dashboard named "Mercure" is loaded
 
+@tested
   Scenario: Filter Dashboard Cards
     When click nav menu item "Dashboards"
     #When hover over the "Dashboards" menu item
@@ -163,6 +171,7 @@ Feature: Dashboards - Base
     Then close all notifications
     Then there is a dashboard card named "Alpha Centauri"
 
+@tested
   Scenario: Import Dashboard paste json
     When click create dashboard control
     When click the create dashboard item "Import Dashboard"
@@ -176,6 +185,7 @@ Feature: Dashboards - Base
     Then close all notifications
     Then there is a dashboard card named "Tau Ceti"
 
+@tested
   Scenario: Create Dashboard from template
     When create a new template from the file "etc/test-data/sine-test-template.json" for user "DEFAULT"
     When click nav menu item "Dashboards"
@@ -199,6 +209,7 @@ Feature: Dashboards - Base
     When click Dashboard from Template create button
     Then there is a dashboard card named "Sinusoid test data"
 
+@tested
   Scenario: Sort Dashboards by Name
     When close all notifications
     Then the dashboards are sorted as:
@@ -257,6 +268,7 @@ Feature: Dashboards - Base
     Then the file "tau_ceti.json" has been downloaded
     When remove file "tau_ceti.json" if exists
 
+@tested
   Scenario: Clone Dashboard
     When hover over dashboard card named "Tau Ceti"
     When click clone of the dashboard card named "Tau Ceti"
@@ -270,6 +282,7 @@ Feature: Dashboards - Base
     #When click nav sub menu "Dashboards"
     Then there is a dashboard card named "Tau Ceti (clone 1)"
 
+@tested
   Scenario Outline: Delete dashboards
     When hover over dashboard card named "<NAME>"
     When click delete of dashboard card "<NAME>"

--- a/features/dashboards/noteCell.feature
+++ b/features/dashboards/noteCell.feature
@@ -73,6 +73,7 @@ Feature: Dashboards - Dashboard - Note Cell
     Then the note cell contains a "ul li" tag with "Rumcajs"
     Then the note cell contains a "ol li" tag with "Alpha"
 
+@tested
   Scenario: Edit note
     When toggle context menu of dashboard cell named "Note"
     When click cell content popover edit note

--- a/features/dashboards/variables.feature
+++ b/features/dashboards/variables.feature
@@ -60,6 +60,7 @@ Feature: Dashboards - Dashboard - Variables
     Then the empty dashboard contains Add a Cell button
     When name dashboard "Semiotic"
 
+@error-collateral
   Scenario: Create Basic Cell for Variables
     When click the empty create cell button
     Then the cell edit overlay is loaded as "Name this Cell"
@@ -74,6 +75,7 @@ Feature: Dashboards - Dashboard - Variables
     When click dashboard cell save button
     Then the dashboard contains a cell named "Semantic"
 
+@error-collateral
   Scenario: Edit Query - Filter variables
     When toggle context menu of dashboard cell named "Semantic"
     When click cell content popover configure
@@ -113,6 +115,7 @@ Feature: Dashboards - Dashboard - Variables
           # Script Editor
              # Variables
 
+@error-collateral
   Scenario:  Add CSV variable to script
     When toggle context menu of dashboard cell named "Semantic"
     When click cell content popover configure
@@ -157,6 +160,7 @@ Feature: Dashboards - Dashboard - Variables
 
 
   #Script with Map variables
+@error-collateral
   Scenario:  Add Map variable to script
     Then the dashboard variables button is highlighted
     When toggle context menu of dashboard cell named "Semantic"
@@ -200,6 +204,7 @@ Feature: Dashboards - Dashboard - Variables
     Then the graph of the cell "Semantic" has changed
 
   #Script with Query variables
+@error-collateral
   Scenario:  Add Query variable to script
     Then the dashboard variables button is highlighted
     When toggle context menu of dashboard cell named "Semantic"
@@ -244,6 +249,7 @@ Feature: Dashboards - Dashboard - Variables
 
 
    #Change variables in Dashboard view two cells same variable.
+@error-collateral
   Scenario: Change variables in Dashboard view - two cells
     When click the header add cell button
     Then the cell edit overlay is loaded as "Name this Cell"
@@ -267,6 +273,7 @@ from(bucket: "qa")
     Then the graph of the cell "Semantic" has changed
     Then the graph of the cell "Syntagma" has changed
 
+@error-collateral
   Scenario: Change variables in Dashboard view - two variables
     When toggle context menu of dashboard cell named "Syntagma"
     When click cell content popover configure
@@ -300,6 +307,7 @@ from(bucket: "qa")
 
 
   #Dashboard view show/hide variables.
+@error-collateral
   Scenario: Toggle Variables in Dashboard
     Then the value dropdown for variable "POKUS" is visible
     Then the dashboard variables button is highlighted
@@ -314,7 +322,6 @@ from(bucket: "qa")
 
   # NEED TO CLEAN UP
   # Variables cached in localstore can influence other tests
-@tested
 @tested
   Scenario Outline: Delete Variable
     When click nav menu item "Settings"

--- a/features/dashboards/variables.feature
+++ b/features/dashboards/variables.feature
@@ -4,6 +4,8 @@ Feature: Dashboards - Dashboard - Variables
   As a user I want to Add Variables to cell Queries
   So that I can view specific Influxdbv2 data sets
 
+@tested
+@tested
   Scenario: Load Cell Edit View
     Given I reset the environment
     Given run setup over REST "DEFAULT"
@@ -312,6 +314,8 @@ from(bucket: "qa")
 
   # NEED TO CLEAN UP
   # Variables cached in localstore can influence other tests
+@tested
+@tested
   Scenario Outline: Delete Variable
     When click nav menu item "Settings"
     When click the settings tab "Variables"

--- a/features/homePage/homePage.feature
+++ b/features/homePage/homePage.feature
@@ -2,7 +2,6 @@
 @homePage-homePage
 Feature: Home Page
 
-  @error-timeout
   Scenario: logout home page
     Given I reset the environment
     Given run setup over REST "DEFAULT"

--- a/features/homePage/homePage.feature
+++ b/features/homePage/homePage.feature
@@ -17,6 +17,7 @@ Feature: Home Page
     When I click the panel "Data Collector"
     Then the Telegraf Tab is loaded
 
+@tested
   Scenario: Check Dashboards Panel
     When hover over the "home" menu item
     When click nav menu item "home"
@@ -31,6 +32,7 @@ Feature: Home Page
     When click the dashboard link to "Test Dashboard"
     Then the dashboard named "Test Dashboard" is loaded
 
+@tested
   Scenario: Click Alerting Panel
     When hover over the "home" menu item
     When click nav menu item "home"

--- a/features/influx/influx.feature
+++ b/features/influx/influx.feature
@@ -3,7 +3,6 @@
 Feature: Influx common
   Click through the controls common to all influx pages
 
-  @error-timeout
   Scenario: Open home page
     Given I reset the environment
     Given run setup over REST "DEFAULT"

--- a/features/influx/influx.feature
+++ b/features/influx/influx.feature
@@ -3,6 +3,7 @@
 Feature: Influx common
   Click through the controls common to all influx pages
 
+@tested
   Scenario: Open home page
     Given I reset the environment
     Given run setup over REST "DEFAULT"
@@ -13,6 +14,7 @@ Feature: Influx common
     #Then the header contains the org name "DEFAULT"
     Then the home page header contains "Getting Started"
 
+@tested
   Scenario: Click Data Explorer
     #Then the menu item text "Data Explorer" is "hidden"
     #When hover over the "explorer" menu item
@@ -20,6 +22,7 @@ Feature: Influx common
     When click nav menu item "Explorer"
     Then the Data Explorer page is loaded
 
+@tested
    Scenario: Click Dashboards
      #Then the menu item text "Dashboards" is "hidden"
      #When hover over the "dashboards" menu item
@@ -27,6 +30,7 @@ Feature: Influx common
      When click nav menu item "Dashboards"
      Then the Dashboards page is loaded
 
+@tested
   Scenario: Click Tasks
     #Then the menu item text "Tasks" is "hidden"
     #When hover over the "tasks" menu item
@@ -34,6 +38,7 @@ Feature: Influx common
     When click nav menu item "Tasks"
     Then the Tasks page is loaded
 
+@tested
   Scenario: Click Alerting
     #Then the menu item text "Monitoring & Alerting" is "hidden"
     #When hover over the "alerting" menu item
@@ -41,6 +46,7 @@ Feature: Influx common
     When click nav menu item "Alerting"
     Then the Alerting page is loaded
 
+@tested
   Scenario: Click Load Data
     #Then the menu item text "Settings" is "hidden"
     #When hover over the "loadData" menu item

--- a/features/loadData/buckets.feature
+++ b/features/loadData/buckets.feature
@@ -110,6 +110,7 @@ Scenario: Filter Buckets
   Then the buckets are sorted as "Denní,Půldenní,Týdenní"
   Then the bucket "Oprava" is not in the list
 
+@error-collateral
 Scenario: Clear Filter
   When clear the Buckets filter field
   Then the bucket named "Oprava" is in the list
@@ -131,6 +132,7 @@ Scenario: Sort Buckets by Name
   When click sort by item "Name Desc"
   #Given ensure buckets name sort order "desc"
 
+@error-collateral
 Scenario: Sort Buckets by Retention Policy
   When click the sort type dropdown
   When click sort by item "retentionRules[0].everySeconds-asc"
@@ -184,6 +186,7 @@ Scenario: Add Manual Line Protocol Data to Default
 { "points": 12, "field": "foo", "measurement": "fibonacci", "start": "-3h", "vals": ["1","233"], "rows": ["1","-1"] }
 """
 
+@error-collateral
   Scenario: Add Manual Line Protocol Bad Data to Default
     Then the add data popover is not present
     When click add data button for bucket "DEFAULT"

--- a/features/loadData/buckets.feature
+++ b/features/loadData/buckets.feature
@@ -5,6 +5,7 @@ Feature: Load Data - Buckets
   So that I can manage the stores used with Influxdbv2
 
 
+@tested
 Scenario: List Initial Buckets
   Given I reset the environment
   Given run setup over REST "DEFAULT"
@@ -15,6 +16,7 @@ Scenario: List Initial Buckets
   Then the buckets tab is loaded
   Then the buckets are sorted as "_monitoring,_tasks,DEFAULT"
 
+@tested
 Scenario: Exercise Create Bucket Dialog
   When click the Create Bucket button
   Then the Create Bucket Popup is loaded
@@ -65,6 +67,7 @@ Scenario: Exercise Create Bucket Dialog
   When cancel the Create Bucket Popup
   Then the Create Bucket Popup is not present
 
+@tested
 Scenario Outline: Create Buckets with Retention Policies
   When click the Create Bucket button
   When input the name of the bucket as "<NAME>"
@@ -83,6 +86,7 @@ Examples:
   | Hodinová  | 1h |
   | Oprava    | 24h  |
 
+@tested
 Scenario: Modify Retention Policy
   When click on settings for bucket named "Oprava"
   Then the Edit Bucket popup is loaded
@@ -100,6 +104,7 @@ Scenario: Modify Retention Policy
   # N.B. fix following once issue 14905 is resolved
   Then the bucket named "Oprava" has a Retention Policy of "48h"
 
+@tested
 Scenario: Filter Buckets
   When enter "denn" in the Buckets filter field
   Then the buckets are sorted as "Denní,Půldenní,Týdenní"
@@ -112,6 +117,7 @@ Scenario: Clear Filter
   Then the bucket named "_tasks" is in the list
   Then the bucket named "Týdenní" is in the list
 
+@tested
 Scenario: Sort Buckets by Name
   When click the sort type dropdown
   When click sort by item "Name Desc"
@@ -135,6 +141,7 @@ Scenario: Sort Buckets by Retention Policy
   #When click buckets sort by retention policy
   Then the buckets are sorted as "DEFAULT,Trvalá,Měsíční,Týdenní,_monitoring,_tasks,Oprava,Denní,Půldenní,Hodinová"
 
+@tested
 Scenario Outline: Delete Buckets
 # following check leads to troublesome false positives - todo fix it
 #  Then the delete button of the card named "<Name>" is not present
@@ -154,6 +161,7 @@ Examples:
   | Oprava    |
 
 
+@tested
 Scenario: Add Manual Line Protocol Data to Default
   Then the add data popover is not present
   When click add data button for bucket "DEFAULT"
@@ -191,6 +199,7 @@ Scenario: Add Manual Line Protocol Data to Default
     When click the Line Protocol wizard finish button
     Then the line Protocol wizard is not present
 
+@tested
   Scenario: Add Line Protocol Data from File to Default
     When generate a line protocol testdata file "etc/test-data/line-protocol-hydro.txt" based on:
     """
@@ -222,6 +231,7 @@ Scenario: Add Manual Line Protocol Data to Default
     { "points": 20, "field": "level", "measurement": "hydro", "start": "-60h", "vals": "skip", "rows": ["1","-1"], "name": "hydro" }
     """
 
+@tested
   Scenario: Add Scraper to Default
     When click add data button for bucket "DEFAULT"
     Then the add data popover for the bucket "DEFAULT" is visible

--- a/features/loadData/loadData.feature
+++ b/features/loadData/loadData.feature
@@ -4,6 +4,7 @@ Feature: Load Data - Base
   As a user I want to open the Load Data page
   So that I can explore how data is being loaded into Influxdbv2
 
+@tested
   Scenario: Verify Tabs
     Given I reset the environment
     Given run setup over REST "DEFAULT"

--- a/features/loadData/loadData.feature
+++ b/features/loadData/loadData.feature
@@ -4,7 +4,6 @@ Feature: Load Data - Base
   As a user I want to open the Load Data page
   So that I can explore how data is being loaded into Influxdbv2
 
-  @error-timeout
   Scenario: Verify Tabs
     Given I reset the environment
     Given run setup over REST "DEFAULT"

--- a/features/loadData/scrapers.feature
+++ b/features/loadData/scrapers.feature
@@ -7,6 +7,7 @@ Feature: Load Data - Scrapers
 # N.B. can verify scrapers at endpoint http://localhost:9999/api/v2/scrapers
 
 
+@tested
 Scenario: Load Initial Scrapers tab
   Given I reset the environment
   Given run setup over REST "DEFAULT"
@@ -18,6 +19,7 @@ Scenario: Load Initial Scrapers tab
   When click load data tab "Scrapers"
   Then the scrapers tab is loaded
 
+@tested
 Scenario: Exercise create Scraper popup
   When click the create scraper button empty
   Then the Create Scraper popup is loaded
@@ -53,6 +55,7 @@ Scenario: Exercise create Scraper popup
   When dismiss the Create Scraper popup
   Then the Create Scraper popup is no longer present
 
+@tested
 Scenario Outline: Create Scrapers
   When click the create scraper button from the header
   When clear the Scraper Popup name input
@@ -131,6 +134,7 @@ Scenario Outline: Verify Scraper data
   |DEFAULT| Duchamp | Measurements | boltdb_reads_total,go_info,go_threads,influxdb_info,storage_reads_seeks |
   |DEFAULT| DEFAULT | Measurements | boltdb_reads_total,go_info,go_threads,influxdb_info,storage_reads_seeks |
 
+@tested
 Scenario Outline: Delete Scraper
   Then the delete button of the scraper card named "<NAME>" is not present
   When hover over scraper card named "<NAME>"

--- a/features/loadData/scrapers.feature
+++ b/features/loadData/scrapers.feature
@@ -79,6 +79,7 @@ Scenario Outline: Create Scrapers
   | Brno | http://localhost:10018/bogus | DEFAULT |
   | Brest | http://localhost:10018/bogus | Duchamp |
 
+@error-collateral
 Scenario: Filter Scrapers
   Then the scraper name sort order is "Brest,Brno,Melnik,Morlaix"
   When enter the value "Br" into the scraper filter
@@ -88,6 +89,7 @@ Scenario: Filter Scrapers
   When clear the scraper filter
   Then the scraper name sort order is "Brest,Brno,Melnik,Morlaix"
 
+@error-collateral
 Scenario: Sort Scrapers by Name
   When click the sort type dropdown
   When click sort by item "Name Desc"
@@ -98,6 +100,7 @@ Scenario: Sort Scrapers by Name
   #When click the scraper sort by name button
   Then the scraper name sort order is "Brest,Brno,Melnik,Morlaix"
 
+@error-collateral
 Scenario: Sort Scrapers by URL
   When click the sort type dropdown
   When click sort by item "URL Asc"
@@ -108,6 +111,7 @@ Scenario: Sort Scrapers by URL
   #When click the scraper sort By URL button
   Then the scraper name sort order is "Melnik,Morlaix,Brno,Brest"
 
+@error-collateral
 Scenario: Sort Scrapers by Bucket
   When click the sort type dropdown
   When click sort by item "Bucket Asc"
@@ -118,6 +122,7 @@ Scenario: Sort Scrapers by Bucket
   #When click the scraper sort By Bucket button
   Then the scraper name sort order is "Melnik,Brno,Morlaix,Brest"
 
+@error-collateral
 Scenario: Rename Scraper
   When hover over the scraper card name "Brno"
   When click the scraper card name edit control for the card "Brno"
@@ -126,6 +131,7 @@ Scenario: Rename Scraper
   Then there is a scraper card for "Plzeň"
   Then the scraper card "Brno" is no longer present in the list
 
+@error-collateral
 Scenario Outline: Verify Scraper data
   Then the named query "<NAMED_QUERY>" by user "<USER>" on the bucket "<BUCKET>" contains the values "<EXPECTED_VALUES>"
 

--- a/features/loadData/telegrafs.feature
+++ b/features/loadData/telegrafs.feature
@@ -15,7 +15,6 @@ Scenario: Load Initial Telegraf tab
   When click load data tab "Telegrafs"
   Then the telegrafs tab is loaded
 
-@error-feature
 Scenario: Exercise create Telegraf wizard
   When click the create Telegraf button empty
   Then the Create Telegraf Wizard is loaded
@@ -41,7 +40,6 @@ Scenario: Exercise create Telegraf wizard
   Then the Create Telegraf Wizard is no longer present
   When click the create Telegraf button empty
 
-@error-collateral
 Scenario Outline: Edit Plugin Values
   When click the plugin tile "<PLUGIN>" in the Create Telegraf Wizard
   When click the Popup Wizard continue button
@@ -107,7 +105,6 @@ Scenario: Cleanup from Edit Plugin Values
   When dismiss the Create Telegraf Wizard
 
 #N.B. just add UI artifacts - no need to check backend at this point
-@error-feature
 Scenario Outline: Create Telegraf
   When click the create Telegraf button in header
   When click the select bucket dropdown in the Create Telegraf Wizard
@@ -134,7 +131,6 @@ Scenario Outline: Create Telegraf
     | NGINX      | Duchamp |Nymburk    | Lorem ipsum  | SKIP |
     | Redis      | DEFAULT |Rakovnik   | Lorem ipsum  | SKIP |
 
-@error-collateral
 Scenario: Sort Telegrafs by Name
   Then the telegraf sort order is "Decin,Kladno,Nymburk,Rakovnik,Strakonice"
   When click the sort type dropdown
@@ -146,7 +142,6 @@ Scenario: Sort Telegrafs by Name
   #When click the telegraf sort by name button
   Then the telegraf sort order is "Decin,Kladno,Nymburk,Rakovnik,Strakonice"
 
-@error-collateral
 Scenario: Filter Telegrafs
   When enter the value "Rak" into the Telegrafs filter
   Then the telegraf sort order is "Rakovnik,Strakonice"
@@ -154,21 +149,18 @@ Scenario: Filter Telegrafs
   When clear the Telegrafs filter
   Then the telegraf sort order is "Decin,Kladno,Nymburk,Rakovnik,Strakonice"
 
-@error-feature
 Scenario: Verify setup instructions
   When click on setup instructions for the telegraf card "Decin"
   Then the telegraf setup instruction popup is loaded
   When dismiss the popup
   Then popup is not loaded
 
-@error-feature
 Scenario: Verify configuration
   When click on the name of the telegraf card "Nymburk"
   Then the telegraf configuration popup for "Nymburk" is loaded
   When dismiss the popup
   Then popup is not loaded
 
-@error-feature
 Scenario: Edit Telegraf Card
   When hover over the name of the telegraf card "Nymburk"
   When click the name edit icon of the telegraf card "Nymburk"
@@ -182,7 +174,6 @@ Scenario: Edit Telegraf Card
   When set the description input of the telegraf card "Norimberk" to "Hunt the Wumpus"
   Then the description of the telegraf card "Norimberk" is "Hunt the Wumpus"
 
-@error-feature
   Scenario: Add labels to telegraf
     Then the Label Popup for the Telegraf Card "Kladno" is not present
     When click Add Label for Telegraf Card "Kladno"
@@ -206,7 +197,6 @@ Scenario: Edit Telegraf Card
     When dismiss the popup
     Then popup is not loaded
 
-@error-feature
   Scenario: Delete label from telegraf
     When hover over the label pill "Cesko" for the Telegraf Card "Kladno"
     When click delete the label pill "Cesko" for the Telegraf Card "Kladno"
@@ -218,7 +208,6 @@ Scenario: Edit Telegraf Card
     When click telegraf card "Kladno"
     Then the Label Popup for the Telegraf Card "Kladno" is not present
 
-@error-feature
 Scenario Outline: Delete Telegraf Card
   When hover over telegraf card "<NAME>"
   When click delete for telegraf card "<NAME>"

--- a/features/loadData/tokens.feature
+++ b/features/loadData/tokens.feature
@@ -72,6 +72,7 @@ Feature: Load Data - Tokens
     When click popup cancel button
     Then popup is not loaded
 
+@error-collateral
   Scenario: Exercise Create All Access Token Popup
     When click the generate token dropdown
     When click the generate token item "all-access"
@@ -116,6 +117,7 @@ Feature: Load Data - Tokens
 
   # Scenario: Sort By Status # not working see issue 15301
 
+@error-collateral
   Scenario: Sort By Name
     Then the first tokens are sorted by description as "admin's Token, Campbells Soup, Dismaland, La Femme a la perle, La Jocande"
     When click the tokens sort By Name button
@@ -123,6 +125,7 @@ Feature: Load Data - Tokens
     When click the tokens sort By Name button
     Then the first tokens are sorted by description as "admin's Token, Campbells Soup, Dismaland, La Femme a la perle, La Jocande"
 
+@error-collateral
   Scenario: Edit Description
     When hover over the token description "La Jocande"
     When click the token description toggle for "La Jocande"

--- a/features/loadData/tokens.feature
+++ b/features/loadData/tokens.feature
@@ -2,6 +2,7 @@
 @loadData-tokens
 Feature: Load Data - Tokens
 
+@tested
   Scenario: Load Initial Tokens tab
     Given I reset the environment
     Given run setup over REST "DEFAULT"
@@ -16,6 +17,7 @@ Feature: Load Data - Tokens
     Then the tokens tab is loaded
     Then the tokens list contains the token described as "admin's Token"
 
+@tested
   Scenario: Exercise Create Read/Write Token Popup
     When click the generate token dropdown
     When click the generate token item "read-write"
@@ -81,6 +83,7 @@ Feature: Load Data - Tokens
     When click all-access token popup cancel
     Then popup is not loaded
 
+@tested
   Scenario Outline: Create Token
     When click the generate token dropdown
     When select token type based on <PRIVILEGES> type
@@ -100,6 +103,7 @@ Feature: Load Data - Tokens
     | Cambpells Soup            | All       | RW |
     | La Jocande   | ALL                    |ALL |
 
+@tested
   Scenario Outline: Disable Token
     When disable the token described as <DESCR>
     Then the token described as <DESCR> is disabled
@@ -129,12 +133,14 @@ Feature: Load Data - Tokens
     Then the tokens list does not contain the token described as "La Jocande"
     When close all notifications
 
+@tested
   Scenario: Enable Token
     When enable the token described as "Nu descendant un escalier"
     Then the token described as "Nu descendant un escalier" is enabled
     Then the success notification contains "Token was updated successfully"
     When close all notifications
 
+@tested
   Scenario Outline: Review Token
     When click on the token described as "<DESCR>"
     Then the review token popup is loaded
@@ -149,6 +155,7 @@ Feature: Load Data - Tokens
     | Cambpells Soup            | All       | read,write |
     | La Dame a l hermine   | ALL                    |ALL |
 
+@tested
   Scenario Outline: Delete Token
     When hover over token card described as "<DESCR>"
     When click the delete button of the token card described as "<DESCR>"

--- a/features/monitoring/alerts.feature
+++ b/features/monitoring/alerts.feature
@@ -5,6 +5,7 @@ Feature: Monitoring - Alerts - Base
   As a user I want to setup alerts
   So that I can be notified of important changes in the data
 
+@tested
 Scenario: Load Initial Alerts view
   Given I reset the environment
   Given run setup over REST "DEFAULT"
@@ -27,6 +28,7 @@ Scenario: Load Initial Alerts view
   Then the Alerting page is loaded
   When wait "10" seconds
 
+@tested
 Scenario: Exercise Initial Alerts view Controls
   Then the notification rules create dropdown is disabled
   When click alerting tab "checks"
@@ -72,6 +74,7 @@ Scenario: Exercise Initial Alerts view Controls
 # TODO - Check illogical alert thresholds
 # TODO - add simple tags check
 
+@tested
   Scenario: Exercise Configure Check - Threshold
     When click the create check button
     When click the create check dropdown item "Threshold"
@@ -171,6 +174,7 @@ Scenario: Exercise Initial Alerts view Controls
     Then the first time create deadman check is visible
 
 # Create Threshold Alerts
+@tested
   Scenario: Create Simple Threshold Check
     When click the first time create threshold check
     Then the create check checklist contains:
@@ -295,6 +299,7 @@ Que ta voix, chat mystérieux, Chat séraphique, chat étrange... Baudelaire
   """
 
 # Add labels to checks
+@tested
 Scenario: Add Labels To Checks
   When click empty label for check card "Deadman Critical Check"
   Then the add label popover is present

--- a/features/monitoring/alerts.feature
+++ b/features/monitoring/alerts.feature
@@ -136,6 +136,7 @@ Scenario: Exercise Initial Alerts view Controls
     Then the first time create threshold check is visible
     Then the first time create deadman check is visible
 
+@error-collateral
   Scenario: Exercise configure check Deadman
   # Just check Deadman fields others were covered in threshold test
     When click the create check button
@@ -223,6 +224,7 @@ ${ r._check_name } is: ${ r._level } value was ${string(v: r.val)}
     Then there is an alert card named "Simple Count Check"
 
     # Create Deadman Alerts
+@error-collateral
   Scenario: Create simple Critical Deadman Check
   # Just check Deadman fields others were covered in threshold test
     When click the create check button
@@ -251,6 +253,7 @@ ${ r._check_name } is: ${ r._level } value [${string(v: r.val)}] has stopped rep
     Then there is an alert card named "Deadman Critical Check"
 
   # Need second card for filter and sort tests
+@error-collateral
   Scenario: Create simple Warn Deadman Check
   # Just check Deadman fields others were covered in threshold test
     When click the create check button
@@ -280,6 +283,7 @@ ${ r._check_name } is: ${ r._level } has stopped reporting.  Last value [${strin
 # TODO - EDIT Threshold Check and drag threshold control in graph
 
 # Edit Check Card
+@error-collateral
 Scenario: Edit Check Card
    When hover over the name of the check card "Deadman Warn Check"
    When click the name edit button of the check card "Deadman Warn Check"
@@ -364,6 +368,7 @@ Scenario: Add Labels To Checks
   When click the checks filter input
 
 # Clone check
+@error-collateral
   Scenario: Clone Check
     When hover over the name of the check card "Simple Count Check"
     When wait "1" seconds
@@ -398,6 +403,7 @@ ${ r._check_name } is: ${ r._level } value was ${string(v: r.val)}
     Then there is an alert card named "Bécik"
 
 # Filter Checks
+@error-collateral
   Scenario: Filter Checks
     Then the check cards column contains
   """
@@ -463,4 +469,3 @@ ${ r._check_name } is: ${ r._level } value was ${string(v: r.val)}
 
 # NOTE - perhaps should have five features - base, checks, endpoints, rules, full monitoring (too harvest alerts
 # and notifications.) - breakup planned tests above into these feature files.
-

--- a/features/onboarding/onboarding.feature
+++ b/features/onboarding/onboarding.feature
@@ -3,6 +3,7 @@
 Feature: Onboard to Influxdbv2
   Create an initial user and organization
 
+@tested
   Scenario: Onboard Basic
 # Golden path check 1
     Given I reset the environment
@@ -25,6 +26,7 @@ Feature: Onboard to Influxdbv2
     When close all notifications
     Then the home page is loaded
 
+@tested
   Scenario: Onboard Advanced
 # Golden path check 2
     Given I reset the environment
@@ -45,6 +47,7 @@ Feature: Onboard to Influxdbv2
     When click advanced button
     Then the buckets tab is loaded
 
+@tested
   Scenario: Onboard field checks
 # N.B. would expect there to be rules for min/max length or allowed/disallowed characters in user-names
 # however none currently exist -- TODO add tests for such rules if they are ever implemented

--- a/features/settings/labels.feature
+++ b/features/settings/labels.feature
@@ -100,6 +100,7 @@ Scenario: Sort By Name
   When click sort by item "Name Asc"
   Then the first labels are sorted as "Briza,Buk,Habr,Javor,Jilm"
 
+@error-collateral
 Scenario: Sort By Description
   When click the sort type dropdown
   When click sort by item "Properties.Description Asc"

--- a/features/settings/labels.feature
+++ b/features/settings/labels.feature
@@ -4,6 +4,7 @@ Feature: Settings - Labels
   As a user I want to Read Create Update and Delete Labels
   So that I can manage the tag items used with Influxdbv2
 
+@tested
 Scenario: Open Labels Tab
   Given I reset the environment
   Given run setup over REST "DEFAULT"
@@ -13,6 +14,7 @@ Scenario: Open Labels Tab
   When click the settings tab "Labels"
   Then the labels Tab is loaded
 
+@tested
 Scenario: Exercise Create Label Popup
   When I click the empty state Create Label button
   Then the create Label popup is loaded
@@ -52,6 +54,7 @@ Scenario: Exercise Create Label Popup
   When dismiss the popup
   Then popup is not loaded
 
+@tested
 Scenario Outline: Create Label
   When I click the header Create Label button
   When clear the label popup name input
@@ -72,6 +75,7 @@ Scenario Outline: Create Label
   | Javor | Acer pseudoplatanus | #924544 |
   | Bouleau | Betula verrucosa | #F5EAD5 |
 
+@tested
 Scenario: Edit Label
   When I click the Label Card Pill "Bouleau"
   Then the edit label popup is loaded
@@ -86,6 +90,7 @@ Scenario: Edit Label
   Then the label card "Briza" has a pill colored "#ECFC31"
   Then the label card "Briza" has description "Betula pendula"
 
+@tested
 Scenario: Sort By Name
   Then the first labels are sorted as "Briza,Buk,Habr,Javor,Jilm"
   When click the sort type dropdown
@@ -106,6 +111,7 @@ Scenario: Sort By Description
   Then the first labels are sorted as "Jilm,Buk,Habr,Briza,Javor"
 
 
+@tested
   Scenario: Filter Labels
   When clear the labels filter input
   When enter the value "J" into the label filter
@@ -129,6 +135,7 @@ Scenario: Sort By Description
   When clear the labels filter input
   Then the first labels are sorted as "Briza,Buk,Habr,Javor,Jilm"
 
+@tested
 Scenario Outline: Delete Label
   When hover over label card "<NAME>"
   When click delete for the label card "<NAME>"
@@ -142,4 +149,3 @@ Scenario Outline: Delete Label
   | Habr |
   | Javor |
   | Jilm |
-

--- a/features/settings/settings.feature
+++ b/features/settings/settings.feature
@@ -6,7 +6,6 @@ Feature: Settings - Base
 
 # TODO with alerting / load data refactor now submenu is richer
 
-  @error-timeout
   Scenario: Verify Tabs
     Given I reset the environment
     Given run setup over REST "DEFAULT"

--- a/features/settings/templates.feature
+++ b/features/settings/templates.feature
@@ -54,6 +54,7 @@ Feature: Settings - Templates
 
 # TODO add variables to templates
 
+@error-collateral
   Scenario Outline: Import User Template File Upload
     When click user templates
     When click header import template button
@@ -75,6 +76,7 @@ Feature: Settings - Templates
     |Hydro test dashboard-Template|etc/test-data/hydro-test-template.json|
     |Note Dashboard-Template|etc/test-data/note-dboard-template.json|
 
+@error-collateral
   Scenario Outline: Import User Template as JSON
     When click header import template button
     Then click the import template paste button
@@ -96,6 +98,7 @@ Feature: Settings - Templates
     |Sinusoid test data-Template|etc/test-data/sine-test-template.json|
     |Notepad-Template|etc/test-data/notepad-test-template.json|
 
+@error-collateral
   Scenario: Import Bad Template File
     When click user templates
     When click header import template button
@@ -105,6 +108,7 @@ Feature: Settings - Templates
     Then the error notification contains "Failed to import template: Error: Request failed with status code 400"
     When close all notifications
 
+@error-collateral
   Scenario: Filter Templates
     When click user templates
     When enter the value "Note" into the templates filter field
@@ -119,6 +123,7 @@ Feature: Settings - Templates
     Hydro test dashboard-Template,Note Dashboard-Template,Notepad-Template,Sinusoid test data-Template
     """
 
+@error-collateral
   Scenario: Sort Templates by Name
     When click the sort type dropdown
     When click sort by item "Meta.Name Desc"
@@ -149,6 +154,7 @@ Feature: Settings - Templates
   # Scenario: Create Dashboard from Template
   # Covered in Dashboard tests
 
+@error-collateral
   Scenario Outline: Delete template
     When hover over template card named "<NAME>"
     When click the context delete button of template "<NAME>"

--- a/features/settings/templates.feature
+++ b/features/settings/templates.feature
@@ -4,6 +4,7 @@ Feature: Settings - Templates
   As a user I want to Read Create Update and Delete Templatess
   So that I can eventually use them to create dashboards in Influxdbv2
 
+@tested
   Scenario: Open Templates Tab
     Given I reset the environment
     Given run setup over REST "DEFAULT"
@@ -27,6 +28,7 @@ Feature: Settings - Templates
     """
 
 
+@tested
   Scenario: Exercise Import Template Popup
     When click user templates
     When click empty state import template button

--- a/features/settings/variables.feature
+++ b/features/settings/variables.feature
@@ -33,6 +33,7 @@ Feature: Settings - Variables
     Then dismiss the popup
     Then popup is not loaded
 
+@tested
   Scenario: Exercise Create Variable Popup
     When click create variable dropdown in header
     When click "new" variable dropdown item
@@ -93,6 +94,7 @@ Feature: Settings - Variables
 
 
   # TODO - failover on bad variable file
+@tested
   Scenario: Import Bad Variable
     When click create variable dropdown in header
     When click "import" variable dropdown item
@@ -326,6 +328,7 @@ Feature: Settings - Variables
     Then close all notifications
     Then there is a variable card for "Kybl"
 
+@tested
   Scenario Outline: Delete Variable
     When hover over variable card named "<NAME>"
     When click delete menu of variable card named "<NAME>"
@@ -344,9 +347,3 @@ Feature: Settings - Variables
       |Obdobi    |
       |Primaty   |
       |Reals     |
-
-
-
-
-
-

--- a/features/signin/signin.feature
+++ b/features/signin/signin.feature
@@ -17,6 +17,7 @@ Feature: Signin
     When click the signin button
     Then the home page is loaded
 
+@tested
    Scenario Outline: Signin Bad Credentials
      Given I reset the environment
      Given run setup over REST "DEFAULT"


### PR DESCRIPTION
@121watts and I went through the scenarios and noted tests believed to be tested in cypress. To reduce the amount of testing redundancy (and speed up tests in our pipeline) we've tagged these tests so we can skip them in the pipeline (relying on the tests in cypress).

 - [x] tag tests that break due to skipping `@tested` tagged tests